### PR TITLE
Update functions-bindings-cosmosdb-v2.md

### DIFF
--- a/articles/azure-functions/functions-bindings-cosmosdb-v2.md
+++ b/articles/azure-functions/functions-bindings-cosmosdb-v2.md
@@ -921,7 +921,7 @@ Here's the binding data in the *function.json* file:
     "collectionName": "MyCollection",
     "id" : "{queueTrigger_payload_property}",
     "partitionKey": "{queueTrigger_payload_property}",
-    "connectionStringSettingStringSetting": "MyAccount_COSMOSDB",     
+    "connectionStringSetting": "MyAccount_COSMOSDB",     
     "direction": "in"
 },
 {


### PR DESCRIPTION
fix the typo of 

connectionStringSettingStringSetting to connectionStringSetting in https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2#input---javascript-examples